### PR TITLE
Fix application ID value in AndroidManifest.xml

### DIFF
--- a/samples/CameraAccess/app/src/main/AndroidManifest.xml
+++ b/samples/CameraAccess/app/src/main/AndroidManifest.xml
@@ -16,7 +16,7 @@
         <!-- Without Developer Mode, this key will need to be set with ID from app registered in Wearables Developer Center -->
         <meta-data
             android:name="com.meta.wearable.mwdat.APPLICATION_ID"
-            android:value="0"
+            android:value="\ 0"
             />
 
         <activity


### PR DESCRIPTION
Numerics are converted to numbers otherwise

  Key com.meta.wearable.mwdat.APPLICATION_ID expected String but value was a java.lang.Integer.  The default value <null> was returned.
19:29:23.142 Bundle            W  Attempt to cast generated internal exception:
                                  java.lang.ClassCastException: java.lang.Integer cannot be cast to java.lang.String